### PR TITLE
testsuite: add simple tests for path handling

### DIFF
--- a/t/t1005-cmddriver.t
+++ b/t/t1005-cmddriver.t
@@ -87,5 +87,15 @@ test_expect_success 'flux env passes cmddriver option to argument' "
 	flux -F --tmpdir /xyx env sh -c 'echo \$FLUX_TMPDIR' \
 		| grep ^/xyx$
 "
-
+# push /foo twice onto PYTHONPATH -- ensure it is leftmost position:
+test_expect_success 'cmddriver pushes dup path elements onto front of PATH' "
+	flux -P /foo env flux -P /bar env flux -P /foo env \
+		sh -c 'echo \$PYTHONPATH' | grep '^/foo'
+"
+# Ensure PATH-style variables are de-duplicated on push
+# Push /foo twice onto PYTHONPATH, ensure it appears only once
+test_expect_success 'cmddriver deduplicates path elements on push' "
+	flux -P /foo env flux -P /foo env sh -c 'echo \$PYTHONPATH' |
+		awk -F '/foo' 'NF-1 != 1 {print; exit 1}'
+"
 test_done


### PR DESCRIPTION
Add a couple simple tests for path element handling in the flux(1)
command driver. These tests attempt to verify that path elements are
pushed to the head of PATH-style environment variables and that the
pushed elements are de-duplicated in the resulting variable value.

I verified that the final test here fails on current master and succeeds on your branch.
